### PR TITLE
add @Nonnull to get() method in ArrayMap to avoid NPE

### DIFF
--- a/src/main/java/com/simplaex/bedrock/ArrayMap.java
+++ b/src/main/java/com/simplaex/bedrock/ArrayMap.java
@@ -42,7 +42,7 @@ public final class ArrayMap<K extends Comparable<? super K>, V> implements Mappi
   @SuppressWarnings("unchecked")
   @Nonnull
   @Override
-  public Optional<V> get(final K key) {
+  public Optional<V> get(@Nonnull final K key) {
     final int ix = Arrays.binarySearch(keys, key);
     if (ix >= 0) {
       return Optional.ofNullable((V) values[ix]);


### PR DESCRIPTION
 Arrays.binarySearch(keys, key) throws NPE when key is Null. This should be communicated in method signature.